### PR TITLE
feat: add sign-in page; refactor close-button, header, form, logo

### DIFF
--- a/src/entities/form/index.tsx
+++ b/src/entities/form/index.tsx
@@ -3,7 +3,7 @@ import FormMui from '~/shared/ui/form-mui';
 import InputMUI from '~/shared/ui/input-mui';
 import ButtonMUI from '~/shared/ui/Button-mui';
 import style from './style';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 
 type Field = {
 	name: string;
@@ -15,7 +15,11 @@ type Field = {
 	required: boolean;
 };
 
-const AuthForm: FC<{ fields: Field[] }> = ({ fields }) => {
+const AuthForm: FC<{
+	fields: Field[];
+	children?: ReactNode | ReactNode[];
+	button: { label: string; isFullWidth: boolean; width?: number };
+}> = ({ fields, children, button }) => {
 	const {
 		register,
 		handleSubmit,
@@ -56,12 +60,14 @@ const AuthForm: FC<{ fields: Field[] }> = ({ fields }) => {
 						fullWidth
 					/>
 				))}
-
+			{children && children}
 			<ButtonMUI
-				label="Далее"
-				variant="contained"
 				type="submit"
+				variant="contained"
 				disabled={!isDirty || !isValid}
+				{...button}
+				fullwidth={button.isFullWidth}
+				sx={{ width: `${button.width}px` }}
 			/>
 		</FormMui>
 	);

--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -6,33 +6,45 @@ import AppBarMUI from '~/shared/ui/app-bar-mui';
 import Logo from '../../shared/ui/Logo';
 import style from './style';
 import { FC } from 'react';
+import CloseButton from '~/shared/ui/close-button';
 
 type HeaderProps = {
 	user: {
 		name: string;
 	};
 	isLoggedIn: boolean;
+	type: 'auth' | 'standard';
 };
 
-const Header: FC<HeaderProps> = ({ user, isLoggedIn }) => {
+const Header: FC<HeaderProps> = ({ user, isLoggedIn, type }) => {
 	const theme = useTheme();
 	const isMediumUp = useMediaQuery(theme.breakpoints.up('md'));
 
 	return (
-		<AppBarMUI sx={style.header} color="inherit" position="static">
-			<Logo />
-			{isMediumUp && (
+		<AppBarMUI
+			sx={{
+				...style.header,
+				justifyContent: type === 'auth' ? 'center' : 'space-between',
+			}}
+			elevation={0}
+			color="inherit"
+			position="static"
+		>
+			<Logo type={type === 'standard' ? 'full' : 'image'} />
+			{isMediumUp && type !== 'auth' && (
 				<ButtonGroupMui>
 					<ButtonMUI label="Мои карты" variant="text" color="primary" />
 					<ButtonMUI label="Каталог" variant="text" color="primary" />
 				</ButtonGroupMui>
 			)}
-
-			<ButtonMUI
-				label={isLoggedIn ? user.name : 'Войти'}
-				variant="contained"
-				color="primary"
-			/>
+			{type !== 'auth' && (
+				<ButtonMUI
+					label={isLoggedIn ? user.name : 'Войти'}
+					variant="contained"
+					color="primary"
+				/>
+			)}
+			{type === 'auth' && <CloseButton sx={style.closeButton} />}
 		</AppBarMUI>
 	);
 };

--- a/src/features/Header/style.ts
+++ b/src/features/Header/style.ts
@@ -4,7 +4,14 @@ const style = {
 		paddingY: { xs: '14px', sm: '40px' },
 		display: 'flex',
 		flexDirection: 'row',
-		justifyContent: 'space-between',
+	},
+	closeButton: {
+		position: 'absolute',
+		width: '24px',
+		height: '24px',
+		padding: '4px',
+		top: '14px',
+		right: '17px',
 	},
 };
 

--- a/src/features/auth/sign-in/index.tsx
+++ b/src/features/auth/sign-in/index.tsx
@@ -1,3 +1,4 @@
+import { Link, List, ListItem } from '@mui/material';
 import AuthForm from '~/entities/form';
 
 const SignInForm = () => {
@@ -21,7 +22,19 @@ const SignInForm = () => {
 			placeholder: '',
 		},
 	];
-	return <AuthForm fields={fields} />;
+
+	return (
+		<AuthForm fields={fields} button={{ label: 'Войти', isFullWidth: true }}>
+			<List sx={{ fontSize: '12px', fontWeight: 300 }}>
+				<ListItem dense disableGutters>
+					<Link>Забыли пароль?</Link>
+				</ListItem>
+				<ListItem dense disableGutters>
+					<Link>Нужна помощь?</Link>
+				</ListItem>
+			</List>
+		</AuthForm>
+	);
 };
 
 export default SignInForm;

--- a/src/features/auth/sign-up/index.tsx
+++ b/src/features/auth/sign-up/index.tsx
@@ -48,7 +48,9 @@ const SignUpForm = () => {
 			placeholder: '',
 		},
 	];
-	return <AuthForm fields={fields} />;
+	return (
+		<AuthForm fields={fields} button={{ label: 'Далее', isFullWidth: true }} />
+	);
 };
 
 export default SignUpForm;

--- a/src/page/AuthLayout.tsx
+++ b/src/page/AuthLayout.tsx
@@ -1,8 +1,18 @@
+import { Box } from '@mui/material';
 import { Outlet } from 'react-router-dom';
+import Header from '~/features/Header';
+import { AppFooter } from '~/shared/ui/app-footer';
 
-export const AuthLayout = () => (
-	<div>
-		<div>header</div>
-		<Outlet />
-	</div>
-);
+export const AuthLayout = () => {
+	//TODO: Temporary values
+	const user: { name: string } = { name: '' };
+	const isLoggedIn: boolean = false;
+
+	return (
+		<Box component="main">
+			<Header user={user} isLoggedIn={isLoggedIn} type="auth" />
+			<Outlet />
+			<AppFooter />
+		</Box>
+	);
+};

--- a/src/page/Signin.tsx
+++ b/src/page/Signin.tsx
@@ -1,1 +1,28 @@
-export const Signin = () => <div>signin content</div>;
+import { Container, Typography } from '@mui/material';
+import SignInForm from '~/features/auth/sign-in';
+
+export const Signin = () => {
+	return (
+		<Container
+			component="section"
+			sx={{
+				display: 'flex',
+				flexDirection: 'column',
+				padding: '30px',
+			}}
+		>
+			<Typography
+				align="center"
+				component="h1"
+				sx={{
+					fontSize: '18px',
+					fontWeight: 700,
+					paddingY: '30px',
+				}}
+			>
+				Вход
+			</Typography>
+			<SignInForm />
+		</Container>
+	);
+};

--- a/src/shared/ui/Logo/Logo.css
+++ b/src/shared/ui/Logo/Logo.css
@@ -2,18 +2,9 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+	align-items: center;
 }
 
 .logo__image {
 	width: 55px;
-}
-
-/* Временное решение */
-.logo__title {
-	color: #000;
-	font-family: Nunito;
-	font-size: 17.518px;
-	font-style: normal;
-	font-weight: 700;
-	line-height: normal;
 }

--- a/src/shared/ui/Logo/index.tsx
+++ b/src/shared/ui/Logo/index.tsx
@@ -1,11 +1,22 @@
+import { FC } from 'react';
+import { Typography } from '@mui/material';
 import logoPath from '../../assets/logo.svg';
 import './Logo.css';
+import style from './style';
 
-const Logo = () => {
+type Logo = {
+	type: 'image' | 'full';
+};
+
+const Logo: FC<Logo> = ({ type }) => {
 	return (
 		<div className="logo">
 			<img className="logo__image" alt="Логотип проекта" src={logoPath} />
-			<p className="logo__title">Скидывай</p>
+			{type === 'full' && (
+				<Typography sx={style.title} paragraph>
+					Скидывай
+				</Typography>
+			)}
 		</div>
 	);
 };

--- a/src/shared/ui/Logo/style.ts
+++ b/src/shared/ui/Logo/style.ts
@@ -1,0 +1,10 @@
+const style = {
+	title: {
+		margin: 0,
+		padding: 0,
+		fontSize: '18px',
+		fontWeight: 700,
+	},
+};
+
+export default style;

--- a/src/shared/ui/close-button/index.tsx
+++ b/src/shared/ui/close-button/index.tsx
@@ -1,9 +1,9 @@
 import { IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
-const CloseButton = () => {
+const CloseButton = ({ ...props }) => {
 	return (
-		<IconButton>
+		<IconButton {...props}>
 			<CloseIcon />
 		</IconButton>
 	);


### PR DESCRIPTION
Добавил страницу Sign In. Отрефакторил:
-  Close Button — добавил туда пробрасывание пропсов
-  Header — добавил пропс для двух вариантов отображения ('standard' | 'auth') и добавил условный рендеринг компонентов внутри 
- Logo — добавил пропс для вариантов отображения с названием и без ('image' | 'full') и условный рендеринг
- Form — добавил пропсы для закидывания в форму элементов которые будут рендериться между инпутами и кнопкой и пропсы для управления отображением кнопки.