### PR TITLE
refactor(card entity)

### DIFF
--- a/src/entities/card/index.tsx
+++ b/src/entities/card/index.tsx
@@ -1,64 +1,47 @@
 import { FC } from 'react';
-import { useState } from 'react';
-import { Box, Paper, IconButton } from '@mui/material';
+import { Box, IconButton, Container, Typography } from '@mui/material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import { boxStyle, iconButtonStyle } from './styles';
+import { boxStyle, iconButtonStyle, barcodeStyle, titleStyle } from './styles';
+import Barcode from 'react-barcode';
 
-type CardProps = {
-  card: {
-    _id: string;
-    name: string;
-    number: string;
-    url: string;
-    category: string;
-    isLiked: boolean;
-  };
-  onClickCard(name: string, number: string, url: string): void;
-  onClickLike(card: {
-    _id: string;
-    name: string;
-    number: string;
-    url: string;
-    category: string;
-    isLiked: boolean;
-  }): void;
-};
+interface CardProps {
+  name: string;
+  number: string;
+  category: string;
+  _id: string | number;
+  isLiked: boolean;
+  url?: string;
+}
 
-export const Card: FC<CardProps> = ({ card, onClickCard, onClickLike }) => {
-  const [isLiked, setIsLiked] = useState(card.isLiked);
-
-  function handleClick() {
-    onClickCard(card.name, card.url, card.number);
-  }
-
-  function handleLikeClick() {
-    setIsLiked(!isLiked);
-    onClickLike(card);
-  }
-
+export const Card: FC<CardProps> = ({ name, isLiked, url, number }) => {
   return (
     <>
-      <Paper elevation={2} sx={{ borderRadius: '20px' }}>
-        <Box
-          component="img"
-          sx={{ ...boxStyle }}
-          alt={`скидочная карта от ${card.name}`}
-          src={card.url || '#'}
-          onClick={handleClick}
-        />
-      </Paper>
-      <IconButton
-        aria-label="heart symbol"
-        sx={{ ...iconButtonStyle }}
-        onClick={handleLikeClick}
-      >
-        {card.isLiked ? (
-          <FavoriteIcon fontSize="medium" />
+      <Container>
+        {url ? (
+          <Box sx={{ backgroundImage: `url(${url})`, ...boxStyle }}>
+            <IconButton sx={{ ...iconButtonStyle }}>
+              {isLiked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+            </IconButton>
+            <Box sx={{ ...barcodeStyle }}>
+              <Barcode value={number} />
+            </Box>
+            <Box sx={{ ...barcodeStyle }}>
+              <Barcode value={number} />
+            </Box>
+          </Box>
         ) : (
-          <FavoriteBorderIcon fontSize="medium" />
+          <Box sx={{ backgroundColor: '#52358f', ...boxStyle }}>
+            <IconButton sx={{ ...iconButtonStyle }}>
+              {isLiked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+            </IconButton>
+            <Typography sx={{ ...titleStyle }}>{name}</Typography>
+            <Box sx={{ ...barcodeStyle }}>
+              <Barcode value={number} />
+            </Box>
+          </Box>
         )}
-      </IconButton>
+      </Container>
     </>
   );
 };

--- a/src/entities/card/styles.ts
+++ b/src/entities/card/styles.ts
@@ -1,26 +1,21 @@
 import { SxProps } from '@mui/material';
 
 export const boxStyle: SxProps = {
-  display: 'block',
-  width: '100%',
-  aspectRatio: '1 / 0.63',
-  backgroundColor: '#f6f6f6',
-  objectFit: 'cover',
-  objectPosition: 'center',
-  borderRadius: '20px',
-  overflow: 'hidden',
-  cursor: 'pointer',
-  filter: 'brightness(100%)',
-  transition: 'filter 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-  '&:hover': {
-    filter: 'brightness(90%)',
-  },
+  width: '20.5rem',
+  minHeight: '13.75rem',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: 'cover',
+  borderRadius: '.5rem',
+  color: '#fff',
+  position: 'relative',
+  boxSizing: 'border-box',
+  paddingTop: '1rem',
 };
 
 export const iconButtonStyle: SxProps = {
   position: 'absolute',
-  top: '1rem',
   right: '1rem',
+  top: '1rem',
   color: 'primary.light',
   filter: 'invert(0%)',
   zIndex: '2',
@@ -28,4 +23,24 @@ export const iconButtonStyle: SxProps = {
   '&:hover': {
     filter: 'invert(100%)',
   },
+};
+
+export const barcodeStyle: SxProps = {
+  position: 'absolute',
+  bottom: '1rem',
+  left: '1.3rem',
+  width: '18rem',
+  backgroundColor: '#fff',
+  display: 'flex',
+  justifyContent: 'center',
+};
+
+export const titleStyle: SxProps = {
+  left: '50%',
+  marginX: 'auto',
+  maxWidth: '12.5rem',
+  textAlign: 'center',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
 };

--- a/src/stories/card.stories.ts
+++ b/src/stories/card.stories.ts
@@ -16,26 +16,44 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    card: {
-      url: 'https://i.postimg.cc/h42qWNnk/cloth-shoes-01.jpg',
-      isLiked: false,
-      _id: '0',
-      category: 'category',
-      name: 'name',
-      number: 'number',
-    },
+    url: 'https://i.postimg.cc/h42qWNnk/cloth-shoes-01.jpg',
+    isLiked: false,
+    _id: '0',
+    category: 'category',
+    name: 'name',
+    number: 'number',
   },
 };
 
 export const Secondary: Story = {
   args: {
-    card: {
-      url: 'https://i.postimg.cc/d3L2tnQj/food-01.png',
-      isLiked: true,
-      _id: '0',
-      category: 'category',
-      name: 'name',
-      number: 'number',
-    },
+    url: 'https://i.postimg.cc/d3L2tnQj/food-01.png',
+    isLiked: true,
+    _id: '0',
+    category: 'category',
+    name: 'name',
+    number: 'number',
+  },
+};
+
+export const NoImg: Story = {
+  args: {
+    url: undefined,
+    isLiked: true,
+    _id: '0',
+    category: 'category',
+    name: '24 часа',
+    number: 'number',
+  },
+};
+
+export const NoImgLongName: Story = {
+  args: {
+    url: undefined,
+    isLiked: false,
+    _id: '0',
+    category: 'category',
+    name: 'Очень длинное название для карточки',
+    number: 'number',
   },
 };


### PR DESCRIPTION
Теперь карточка фиксированного размера, как в дизайне и является задним фоном блока, а не картинкой (семантически более верно). Если мы захотим делать адаптив, придётся увеличивать размер карточки брейк-поинтами (или как вариант ширину и высоту задавать не в ремах, а в относительных единицах (например, `calc(100vw - 1rem)`)). 

Убрал все функции, на этапе вёрстки смысла в них нет, а потом дебажить по истории коммитов будет проще. 