### PR TITLE
refactor: added card now render in cards-list

### DIFF
--- a/src/app/contexts/cardsContext.ts
+++ b/src/app/contexts/cardsContext.ts
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, createContext } from 'react';
 import { ICardsContext } from '~/shared';
 
 interface ICardsContextValue {
-  cards: ICardsContext | undefined;
+  cards: ICardsContext | [];
   setCards?: Dispatch<SetStateAction<ICardsContext | undefined>>;
 }
 

--- a/src/entities/add-card-form/index.tsx
+++ b/src/entities/add-card-form/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useContext } from 'react';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import Barcode from 'react-barcode';
@@ -17,6 +17,8 @@ import {
   barcodeStyle,
 } from './style';
 import { AddCardFormModel } from './model';
+import { CardsContext } from '~/app';
+import { ICardContext } from '~/shared';
 
 //NOTE: In case of clearing the field with the built in close-button, the value becomes NULL, so react-hook-form fires type error. That's why we use 'required' error text as invalid type eroor text in shopName field
 const schema = z
@@ -91,6 +93,8 @@ export const AddCardForm: FC<AddCardFormType> = ({
     resolver: zodResolver(schema),
   });
 
+  const { setCards, cards } = useContext(CardsContext);
+
   const onSubmit: SubmitHandler<{ [key: string]: string }> = (data) => {
     const shop = shopList.find((element) => element.name === data.shopName);
     if (shop !== undefined) {
@@ -98,7 +102,12 @@ export const AddCardForm: FC<AddCardFormType> = ({
       new AddCardFormModel(data)
         .createNewCard()
         .then((res) => {
-          console.log(res);
+          const newCard: ICardContext = {
+            card: res,
+            owner: true,
+            favourite: false,
+          };
+          setCards && setCards([...cards, newCard]);
         })
         .catch((err) => {
           console.log(err);

--- a/src/shared/api/ApiRequests.ts
+++ b/src/shared/api/ApiRequests.ts
@@ -1,6 +1,7 @@
 import {
   ICardContext,
   ICardsContext,
+  INewCardResponse,
   IPostCard,
   IShopListContext,
   ISignInRequest,
@@ -27,7 +28,7 @@ interface IApiRequests {
   getUser(): Promise<IUserContext>;
   getShops(): Promise<IShopListContext>;
   getCards(): Promise<ICardsContext>;
-  postCard(data: IPostCard): Promise<ICardContext>;
+  postCard(data: IPostCard): Promise<INewCardResponse>;
   editCard(data: IPostCard, id: number): Promise<void>;
   changeCardLikeStatus(id: number, hasLike: boolean): Promise<ICardContext>;
   deleteCard(id: number): Promise<void>;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -14,6 +14,17 @@ export interface ICardContext {
   favourite: boolean;
 }
 
+export interface INewCardResponse {
+  id: number;
+  shop?: IShop;
+  name: string;
+  pub_date?: string;
+  image?: string | null;
+  card_number?: string;
+  barcode_number?: string;
+  encoding_type?: string;
+}
+
 export interface IUserResponse {
   id: number;
   email: string;


### PR DESCRIPTION
есть интерфейс карточки, в котором несколько полей, включая поле id магазина. Сервер возвращает только поле id магазина при создании карточки, при запросе всех карточек возвращается объект магазина. Из-за этого при размещении карточки не отображается её название.

также я поменял интерфейс контекста - он теперь не может быть undefined. Это нужно, чтобы тс позволял итерировать спред оператором. Вроде ничего не сломалось, но стоит иметь в виду.