### PR TITLE
feat: add copy to clipboard function, refactor Card Widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",
         "@mui/icons-material": "^5.14.16",
+        "copy-to-clipboard": "^3.3.3",
         "react": "^18.2.0",
         "react-barcode": "^1.4.6",
         "react-dom": "^18.2.0",
@@ -8533,6 +8534,14 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.33.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.1.tgz",
@@ -15914,6 +15923,11 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.21.2.tgz",
       "integrity": "sha512-R5Muhi/TUu4i4snWVrMgNoXyJm2f8sJfdgIkQvqb+cuIXQEIMAiWGWgCgYXHqX4+XiS/Bnm7IYZ9Zy6NVe6lhw=="
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.3.2",
     "@mui/icons-material": "^5.14.16",
+    "copy-to-clipboard": "^3.3.3",
     "react": "^18.2.0",
     "react-barcode": "^1.4.6",
     "react-dom": "^18.2.0",

--- a/src/entities/edit-card-form/index.tsx
+++ b/src/entities/edit-card-form/index.tsx
@@ -1,15 +1,16 @@
 import { FC, useContext } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { Box, Button, InputAdornment, IconButton } from '@mui/material';
-import { Input } from '~/shared/ui';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ErrorIcon from '@mui/icons-material/Error';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { cardFormErrors } from '~/shared/lib';
-import { formStyle, buttonStyle } from './style';
-import { ICardContext, IPatchCard, api } from '~/shared';
+import copy from 'copy-to-clipboard';
 import { CardsContext } from '~/app';
+import { Input } from '~/shared/ui';
+import { cardFormErrors } from '~/shared/lib';
+import { ICardContext, IPatchCard, api } from '~/shared';
+import { formStyle, buttonStyle } from './style';
 
 const schema = z
   .object({
@@ -68,6 +69,7 @@ export const EditCardForm: FC<EditCardFormProps> = ({
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isValid },
   } = useForm<{ [key: string]: string }>({
     mode: 'onTouched',
@@ -125,6 +127,10 @@ export const EditCardForm: FC<EditCardFormProps> = ({
             <InputAdornment position="end">
               <IconButton
                 aria-label="Кнопка копирования номера карты"
+                onClick={() => {
+                  copy(watch('cardNumber'));
+                  console.log('Скопировано');
+                }}
                 sx={{
                   padding: 0.2,
                   borderRadius: 0,

--- a/src/widgets/card-widget/index.tsx
+++ b/src/widgets/card-widget/index.tsx
@@ -1,18 +1,12 @@
 import { useContext, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  Button,
-  Container,
-  IconButton,
-  Stack,
-  Box,
-  Typography,
-} from '@mui/material';
+import { Button, IconButton, Stack, Box, Typography } from '@mui/material';
 import CreateIcon from '@mui/icons-material/Create';
 import { BackButton } from '~/features';
 import { CardFull, EditCardForm } from '~/entities';
 import { Liker } from '~/features';
 import {
+  containerStyle,
   buttonStyle,
   topButtonsStyle,
   likerWrapperStyle,
@@ -71,7 +65,7 @@ export const CardWidget = () => {
   };
 
   return (
-    <Container sx={{ display: 'flex', flexDirection: 'column' }}>
+    <Stack useFlexGap sx={containerStyle}>
       <Stack
         direction="row"
         justifyContent="space-between"
@@ -135,6 +129,6 @@ export const CardWidget = () => {
           </Button>
         </Stack>
       )}
-    </Container>
+    </Stack>
   );
 };

--- a/src/widgets/card-widget/style.ts
+++ b/src/widgets/card-widget/style.ts
@@ -1,10 +1,16 @@
 import { SxProps } from '@mui/material';
 
+export const containerStyle: SxProps = {
+  paddingX: '1rem',
+  paddingBottom: '2rem',
+};
+
 export const buttonStyle: SxProps = {
   fontSize: '0.875rem',
   padding: '1.125rem 0',
   textTransform: 'none',
 };
+
 export const topButtonsStyle: SxProps = {
   paddingTop: 2.5,
   paddingBottom: 1.5,


### PR DESCRIPTION
Добавил функционал копирования номера карты в буфер обмена. Отрефакторил Card Widget. Можно вливать после обратного реверта feature/email-activation, поскольку в этой ветке содержится тот код.

closes #74