### PR TITLE
refactor/promo-slider

### DIFF
--- a/src/entities/add-card-form/index.tsx
+++ b/src/entities/add-card-form/index.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import Barcode from 'react-barcode';
 import { Box, TextField, Button, Autocomplete, Card } from '@mui/material';
@@ -120,6 +120,8 @@ export const AddCardForm: FC<AddCardFormType> = ({
     }
   };
 
+  const location = useLocation();
+
   return (
     <Box
       component="form"
@@ -141,7 +143,7 @@ export const AddCardForm: FC<AddCardFormType> = ({
             freeSolo
             fullWidth
             autoSelect
-            value={value}
+            value={location.state.shop.name || value}
             options={shops.map((option) => option.name)}
             renderInput={(params) => (
               <TextField

--- a/src/entities/promo-card/index.tsx
+++ b/src/entities/promo-card/index.tsx
@@ -1,4 +1,5 @@
 import { FC, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card, IconButton } from '@mui/material';
 import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined';
 import { UserContext } from '~/app';
@@ -16,9 +17,10 @@ interface PromoCardProps {
 
 export const PromoCard: FC<PromoCardProps> = ({ item }) => {
   const { user } = useContext(UserContext);
+  const navigate = useNavigate();
 
   function handleClick() {
-    return item;
+    navigate('/card/new', { relative: 'path', state: { shop: item } });
   }
 
   return (

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,4 +1,4 @@
-import { Type, Target } from '../enums';
+import { ApiMessageTypes, ApiMessageTargets } from '../enums';
 
 export interface ICard {
   id: number;
@@ -103,6 +103,6 @@ export interface IPostCardWithShop {
 
 export interface IMessageContext {
   message: string;
-  type: Type;
-  target: Target;
+  type: ApiMessageTypes;
+  target: ApiMessageTargets;
 }


### PR DESCRIPTION
Теперь можно добавлять карту из промо-слайдера.
Применила тот же финт с location.state.
плюс переименовала enums в src/shared/types/index.ts

closes #240