### PR TITLE
fix: fix order of adding messages to store

### DIFF
--- a/src/features/auth/sign-in/index.tsx
+++ b/src/features/auth/sign-in/index.tsx
@@ -70,16 +70,10 @@ export const SignInForm: FC<ISignInForm> = ({
       .then(() => {
         const userPromise = getUser()
           .then((res) => {
-            if (!res?.is_active) {
-              addInfoMessage('Email не подтвержден');
-              return res;
-            } else {
-              return res;
-            }
+            !res?.is_active && addInfoMessage('Email не подтвержден');
+            return res;
           })
-          .then((res) => {
-            return setUser(res);
-          });
+          .then((res) => setUser(res));
         const cardsPromise = api.getCards().then((res) => setCards(res));
         return Promise.all([userPromise, cardsPromise]);
       })

--- a/src/features/info-bar/index.tsx
+++ b/src/features/info-bar/index.tsx
@@ -11,26 +11,18 @@ interface ISnackType {
   backgroundColor: string;
   defaultMessage: string;
 }
-interface ISnack {
-  message: IMessageContext;
-  type: ISnackType;
-}
 
 export const InfoBar: FC = () => {
   const messages = useMessages(useShallow((state) => state.messages));
   const setLastShown = useMessages((state) => state.setLastShown);
   const [open, setOpen] = useState(false);
-  const [snack, setSnack] = useState<ISnack | null>(null);
 
   useEffect(() => {
     if (messages?.[0]?.message && !messages?.[0]?.isShown) {
-      setSnack({ message: messages[0], type: snackTypeSelector(messages[0]) });
       setLastShown();
       setOpen(true);
     }
-    //NOTE: Need to update snackbar only on message updates
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages]);
+  }, [messages, setLastShown]);
 
   const handleClose = (
     _event: React.SyntheticEvent | Event,
@@ -66,27 +58,26 @@ export const InfoBar: FC = () => {
   };
 
   return (
-    snack && (
-      <Snackbar
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        open={open}
-        autoHideDuration={4000}
+    <Snackbar
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      open={open}
+      autoHideDuration={4000}
+      onClose={handleClose}
+    >
+      <Alert
+        elevation={6}
+        variant="filled"
         onClose={handleClose}
+        severity={messages?.[0] && snackTypeSelector(messages[0]).severity}
+        icon={false}
+        sx={{
+          width: '100%',
+          backgroundColor:
+            messages?.[0] && snackTypeSelector(messages[0]).backgroundColor,
+        }}
       >
-        <Alert
-          elevation={6}
-          variant="filled"
-          onClose={handleClose}
-          severity={snack.type.severity}
-          icon={false}
-          sx={{
-            width: '100%',
-            backgroundColor: snack.type.backgroundColor,
-          }}
-        >
-          {snack.message.message || snack.type.defaultMessage}
-        </Alert>
-      </Snackbar>
-    )
+        {messages?.[0]?.message}
+      </Alert>
+    </Snackbar>
   );
 };

--- a/src/shared/store/useMessages.ts
+++ b/src/shared/store/useMessages.ts
@@ -15,21 +15,21 @@ interface IuseMessages {
 export const useMessages = create<IuseMessages>()((set) => ({
   messages: [],
   addMessage: (message) =>
-    set((state) => ({ messages: [...state.messages, message] })),
+    set((state) => ({ messages: [message, ...state.messages] })),
   addErrorMessage: (text) =>
     set((state) => {
       const newMessage = { message: text, type: ApiMessageTypes.error };
-      return { messages: [...state.messages, newMessage] };
+      return { messages: [newMessage, ...state.messages] };
     }),
   addInfoMessage: (text) =>
     set((state) => {
       const newMessage = { message: text, type: ApiMessageTypes.info };
-      return { messages: [...state.messages, newMessage] };
+      return { messages: [newMessage, ...state.messages] };
     }),
   addSuccessMessage: (text) =>
     set((state) => {
       const newMessage = { message: text, type: ApiMessageTypes.success };
-      return { messages: [...state.messages, newMessage] };
+      return { messages: [newMessage, ...state.messages] };
     }),
   setLastShown: () =>
     set((state) => {


### PR DESCRIPTION
Поправил порядок добавления сообщений для тостов. Теперь они добавляются в начало массива, где их и ждет Info Bar. Все работает.