### PR TITLE
fix: back navigate

### DIFF
--- a/src/features/back-button-here/index.tsx
+++ b/src/features/back-button-here/index.tsx
@@ -8,7 +8,9 @@ export const BackButtonToUserProfile = () => {
 
   return (
     <Button
-      onClick={() => navigate('/user', { state: { widgetScreen: 'default' } })}
+      onClick={() =>
+        navigate('/user', { replace: true, state: { widgetScreen: 'default' } })
+      }
       variant="text"
       disableRipple
       startIcon={<ArrowBackIosOutlinedIcon sx={iconStyle} />}


### PR DESCRIPTION
Пофиксила навигацию "назад" из UserProfileWidget, раньше приходилось два раза нажимать, чтобы вернуться на "Мои карты".
Так получалось, если до этого сходить на "Подтвердить Email".