### PR TITLE
refactor: some text and font size changes

### DIFF
--- a/src/shared/lib/theme.ts
+++ b/src/shared/lib/theme.ts
@@ -42,10 +42,9 @@ export const lightTheme = createTheme({
       fontSize: '2.125rem',
       fontWeight: 400,
       lineHeight: 1,
-      letterSpacing: '-0.01em',
-      color: '#1C1B1E',
+      color: 'surface.darker',
       textAlign: 'left',
-      '@media (max-width:600px)': {
+      '@media (max-width:760px)': {
         fontSize: '2rem',
       },
     },
@@ -54,7 +53,7 @@ export const lightTheme = createTheme({
       fontWeight: 400,
       lineHeight: 1,
       letterSpacing: 0,
-      color: '#1C1B1E',
+      color: 'surface.darker',
       textAlign: 'left',
       '@media (max-width:600px)': {
         fontSize: '1.5rem',
@@ -69,6 +68,7 @@ export const lightTheme = createTheme({
       styleOverrides: (themeParam) => `
         body {
           background-color:  #e2dce5;
+          overflow-wrap: break-word;
           overscroll-behavior: none;
         }
         #root {

--- a/src/shared/ui/accent-button/index.tsx
+++ b/src/shared/ui/accent-button/index.tsx
@@ -3,13 +3,16 @@ import { styled } from '@mui/material/styles';
 
 const PurpleButton = styled(Button)({
   width: '100%',
-  fontSize: '0.875rem',
+  fontSize: '1.125rem',
   lineHeight: '1.43',
   padding: '1.125rem',
   borderRadius: '.5rem',
   textTransform: 'none',
   boxShadow: 'none',
   backgroundColor: ' primary.main',
+  '@media (max-width:600px)': {
+    fontSize: '1rem',
+  },
   '&:hover': {
     backgroundColor: '#7965af',
   },

--- a/src/shared/ui/outline-button/style.ts
+++ b/src/shared/ui/outline-button/style.ts
@@ -2,10 +2,13 @@ import { SxProps } from '@mui/material';
 
 export const buttonStyle: SxProps = {
   width: '100%',
-  fontSize: '0.875rem',
+  fontSize: '1.125rem',
   lineHeight: '1.43',
   padding: '1.125rem',
   borderRadius: '.5rem',
   textTransform: 'none',
   boxShadow: 'none',
+  '@media (max-width:600px)': {
+    fontSize: '1rem',
+  },
 };

--- a/src/widgets/activation/style.ts
+++ b/src/widgets/activation/style.ts
@@ -15,9 +15,9 @@ export const titleStyle: SxProps = {
 };
 
 export const paragraphStyle: SxProps = {
-  fontSize: '.875rem',
+  fontSize: '1rem',
   fontWeight: 400,
-  lineHeight: 1.42,
+  lineHeight: 1.5,
   paddingTop: '4.875rem',
   paddingBottom: '1.25rem',
 };

--- a/src/widgets/authorization/index.tsx
+++ b/src/widgets/authorization/index.tsx
@@ -55,6 +55,10 @@ export const AuthWidget = () => {
     setCurrentTab(newValue);
   };
 
+  const handleShowDefault = () => {
+    setWidgetScreen('default');
+  };
+
   const handleShowChangeEmail = () => {
     setWidgetScreen('changeEmail');
   };
@@ -80,7 +84,12 @@ export const AuthWidget = () => {
         />
       );
     case 'resetPasswordRequestSuccess':
-      return <ResetPasswordRequestSuccessWidget email={registredEmail} />;
+      return (
+        <ResetPasswordRequestSuccessWidget
+          email={registredEmail}
+          onClose={handleShowDefault}
+        />
+      );
     case 'passwordReset':
       return (
         <PasswordResetRequestWidget

--- a/src/widgets/card-widget/index.tsx
+++ b/src/widgets/card-widget/index.tsx
@@ -17,6 +17,7 @@ import { Liker } from '~/features';
 import {
   containerStyle,
   topButtonsStyle,
+  wrapperStyle,
   paragraphStyle,
   deleteTitleStyle,
   deleteTextStyle,
@@ -121,10 +122,11 @@ export const CardWidget = () => {
           <Stack
             direction="row"
             spacing={1.5}
-            justifyContent="center"
+            justifyContent="flex-center"
             alignItems="center"
+            alignSelf="center"
             useFlexGap
-            sx={{ paddingY: 1.25 }}
+            sx={wrapperStyle}
           >
             <FriendIcon />
             <Typography component="p" sx={{ ...paragraphStyle }}>

--- a/src/widgets/card-widget/style.ts
+++ b/src/widgets/card-widget/style.ts
@@ -33,6 +33,12 @@ export const deleteTextStyle: SxProps = {
   lineHeight: 1.5,
 };
 
+export const wrapperStyle: SxProps = {
+  maxWidth: '100%',
+  paddingY: 1.25,
+  overflow: 'hidden',
+};
+
 export const paragraphStyle: SxProps = {
   fontSize: '.875rem',
   fontWeight: 400,

--- a/src/widgets/change-email/style.ts
+++ b/src/widgets/change-email/style.ts
@@ -10,8 +10,8 @@ export const containerStyle: SxProps = {
 
 export const paragraphStyle: SxProps = {
   paddingX: '1.5rem',
-  fontSize: '.875rem',
-  lineHeight: 1.43,
+  fontSize: '1rem',
+  lineHeight: 1.5,
   fontWeight: 400,
   paddingTop: '3.5rem',
   paddingBottom: '1.75rem',

--- a/src/widgets/home/index.tsx
+++ b/src/widgets/home/index.tsx
@@ -13,11 +13,17 @@ export const Home = () => {
   return (
     <Stack
       component="main"
+      direction="column"
+      justifyContent="stretch"
       useFlexGap
       spacing={2}
       sx={{ ...mainContainerStyle }}
     >
-      <Typography component="p" textAlign="center" sx={{ ...paragraphStyle }}>
+      <Typography
+        component="p"
+        textAlign="center"
+        sx={{ margin: '0 auto', ...paragraphStyle }}
+      >
         Удобный и быстрый доступ к вашим картам лояльности в любом месте
       </Typography>
 

--- a/src/widgets/home/styles.ts
+++ b/src/widgets/home/styles.ts
@@ -2,18 +2,25 @@ import { SxProps } from '@mui/material';
 
 export const mainContainerStyle: SxProps = {
   height: '100%',
-  paddingBottom: '1rem',
+  paddingBottom: { xs: '1.5rem', sm: '2rem' },
   paddingX: { xs: '1rem', sm: '1.5rem' },
 };
 
 export const paragraphStyle: SxProps = {
-  width: '100%',
-  fontSize: '1.125rem',
+  width: '70%',
+  fontSize: '1.25rem',
   fontWeight: 400,
   lineHeight: 1.5,
   letterSpacing: 0,
   '@media (max-width:600px)': {
+    fontSize: '1.125rem',
+  },
+  '@media (max-width:480px)': {
+    width: '90%',
     fontSize: '1rem',
+  },
+  '@media (max-width:360px)': {
+    width: '100%',
   },
 };
 

--- a/src/widgets/reactivation-success/index.tsx
+++ b/src/widgets/reactivation-success/index.tsx
@@ -16,7 +16,7 @@ export const ReactivationSuccessWidget: FC<IReactivationSuccessWidget> = ({
   useEffect(() => {
     const timer: ReturnType<typeof setTimeout> = setTimeout(
       () => onClose(),
-      3000
+      6000
     );
     return () => {
       clearTimeout(timer);
@@ -31,7 +31,9 @@ export const ReactivationSuccessWidget: FC<IReactivationSuccessWidget> = ({
       sx={mainContainerStyle}
     >
       <Typography textAlign="center" sx={paragraphStyle}>
-        {`Мы отправили письмо на адрес ${user?.email} Перейдите по ссылке в письме, чтобы подтвердить почту`}
+        {`Мы отправили письмо на адрес ${user?.email}`}
+        <br />
+        Перейдите по ссылке в письме, чтобы подтвердить почту
       </Typography>
       <Box
         component="img"

--- a/src/widgets/reactivation-success/styles.ts
+++ b/src/widgets/reactivation-success/styles.ts
@@ -19,10 +19,12 @@ export const coverImgStyle: SxProps = {
 };
 
 export const paragraphStyle: SxProps = {
+  width: '90%',
+  margin: '0 auto',
   color: 'surface.dark',
-  fontSize: '.875rem',
+  fontSize: '1rem',
   fontWeight: 400,
-  lineHeight: 1.42,
+  lineHeight: 1.5,
 };
 
 export const linkStyle: SxProps = {

--- a/src/widgets/registration-success/index.tsx
+++ b/src/widgets/registration-success/index.tsx
@@ -20,7 +20,7 @@ export const RegistrationSuccessWidget: FC<{
   useEffect(() => {
     const timer: ReturnType<typeof setTimeout> = setTimeout(
       () => navigate('/'),
-      10000
+      6000
     );
     return () => {
       clearTimeout(timer);
@@ -35,7 +35,9 @@ export const RegistrationSuccessWidget: FC<{
       sx={mainContainerStyle}
     >
       <Typography textAlign="center" sx={paragraphStyle}>
-        {`Мы отправили письмо на адрес ${user?.email} Перейдите по ссылке в письме, чтобы подтвердить почту`}
+        {`Мы отправили письмо на адрес ${user?.email}`}
+        <br />
+        Перейдите по ссылке в письме, чтобы подтвердить почту
       </Typography>
       <Box
         component="img"

--- a/src/widgets/registration-success/styles.ts
+++ b/src/widgets/registration-success/styles.ts
@@ -19,18 +19,20 @@ export const coverImgStyle: SxProps = {
 };
 
 export const paragraphStyle: SxProps = {
+  width: '90%',
+  margin: '0 auto',
   color: 'surface.dark',
-  fontSize: '.875rem',
+  fontSize: '1rem',
   fontWeight: 400,
-  lineHeight: 1.42,
+  lineHeight: 1.5,
 };
 
 export const linkStyle: SxProps = {
   color: 'surface.dark',
   padding: '0 0 0.25rem',
-  fontSize: '.75rem',
+  fontSize: '1rem',
   fontWeight: 400,
-  lineHeight: 1.33,
+  lineHeight: 1.5,
   textDecoration: 'underline',
   textAlign: 'center',
   cursor: 'pointer',

--- a/src/widgets/reset-password-request-success/index.tsx
+++ b/src/widgets/reset-password-request-success/index.tsx
@@ -1,11 +1,22 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { Typography, Box, Stack } from '@mui/material';
 import coverImage from '~/shared/assets/chatbot-bw-1.svg';
 import { mainContainerStyle, coverImgStyle, paragraphStyle } from './styles';
 
 export const ResetPasswordRequestSuccessWidget: FC<{
   email: string;
-}> = ({ email }) => {
+  onClose: () => void;
+}> = ({ email, onClose }) => {
+  useEffect(() => {
+    const timer: ReturnType<typeof setTimeout> = setTimeout(
+      () => onClose(),
+      6000
+    );
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [onClose]);
+
   return (
     <Stack
       direction="column"
@@ -14,7 +25,9 @@ export const ResetPasswordRequestSuccessWidget: FC<{
       sx={mainContainerStyle}
     >
       <Typography textAlign="center" sx={paragraphStyle}>
-        {`Мы отправили письмо на адрес ${email} Перейдите по ссылке в письме, чтобы изменить пароль`}
+        {`Мы отправили письмо на адрес ${email}`}
+        <br />
+        Перейдите по ссылке в письме, чтобы подтвердить почту
       </Typography>
       <Box
         component="img"

--- a/src/widgets/reset-password-request-success/styles.ts
+++ b/src/widgets/reset-password-request-success/styles.ts
@@ -19,10 +19,12 @@ export const coverImgStyle: SxProps = {
 };
 
 export const paragraphStyle: SxProps = {
+  width: '90%',
+  margin: '0 auto',
   color: 'surface.dark',
-  fontSize: '.875rem',
+  fontSize: '1rem',
   fontWeight: 400,
-  lineHeight: 1.42,
+  lineHeight: 1.5,
 };
 
 export const linkStyle: SxProps = {

--- a/src/widgets/user-cards/styles.ts
+++ b/src/widgets/user-cards/styles.ts
@@ -3,16 +3,16 @@ import { SxProps } from '@mui/material';
 export const mainContainerStyle: SxProps = {
   height: '100%',
   paddingX: { xs: '1rem', sm: '1.5rem' },
-  paddingBottom: '1rem',
+  paddingBottom: { xs: '1.5rem', sm: '2rem' },
   justifyContent: 'flex-start',
   alignItems: 'center',
   flexGrow: 1,
 };
 
 export const paragraphStyle: SxProps = {
-  fontSize: '.875rem',
+  fontSize: '1rem',
   fontWeight: 400,
-  lineHeight: 1.43,
+  lineHeight: 1.5,
 };
 
 export const noResultsStackStyle: SxProps = {

--- a/src/widgets/user-profile/index.tsx
+++ b/src/widgets/user-profile/index.tsx
@@ -81,7 +81,12 @@ export const UserProfileWidget = () => {
         />
       );
     case 'resetPasswordRequestSuccess':
-      return <ResetPasswordRequestSuccessWidget email={user?.email || ''} />;
+      return (
+        <ResetPasswordRequestSuccessWidget
+          email={user?.email || ''}
+          onClose={handleShowDefault}
+        />
+      );
     case 'reactivationSuccess':
       return <ReactivationSuccessWidget onClose={handleShowDefault} />;
     case 'default':

--- a/src/widgets/user-profile/style.ts
+++ b/src/widgets/user-profile/style.ts
@@ -11,13 +11,6 @@ export const titleStyle: SxProps = {
   fontWeight: 400,
 };
 
-export const paragraphStyle: SxProps = {
-  fontSize: '.875rem',
-  fontWeight: 400,
-  lineHeight: 1.42,
-  paddingTop: '.75rem',
-};
-
 export const topButtonsStyle: SxProps = {
   padding: '2.5rem 0 1.25rem',
 };

--- a/src/widgets/welcome/index.tsx
+++ b/src/widgets/welcome/index.tsx
@@ -16,7 +16,7 @@ export const Welcome = () => {
     <Container component="main" sx={{ ...mainContainerStyle }}>
       <Typography
         component="h1"
-        variant="h1"
+        variant="h2"
         textAlign="left"
         sx={{ padding: '0 0 1.5rem', width: '100%' }}
       >

--- a/src/widgets/welcome/styles.ts
+++ b/src/widgets/welcome/styles.ts
@@ -5,7 +5,7 @@ export const mainContainerStyle: SxProps = {
   display: 'flex',
   height: '100%',
   paddingX: { xs: '1rem', sm: '1.5rem' },
-  paddingBottom: '1rem',
+  paddingBottom: { xs: '1.5rem', sm: '2rem' },
   flexDirection: 'column',
   justifyContent: 'flex-start',
   alignItems: 'center',
@@ -24,8 +24,8 @@ export const coverImgStyle: SxProps = {
 
 export const paragraphStyle: SxProps = {
   width: '100%',
-  fontSize: '1.5rem',
-  fontWeight: 500,
+  fontSize: '1.25rem',
+  fontWeight: 400,
   lineHeight: 1.5,
   letterSpacing: 0,
   '@media (max-width:600px)': {


### PR DESCRIPTION
- установила  overflow-wrap: break-word для body, теперь длинное имя или почта переносятся построчно
- увеличила шрифт для основных кнопок
- поменяла нижний отступ на Home, Welcome, UserCards
- на Home для верхнего слогана установила передельную ширину  width: '70%' для высоких разрешений, чтобы предложение не вытягивалось в одну строку
- Добавила таймер закрытия для ResetPasswordRequestSuccessWidget